### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Keep your GitHub streak going just like this [Ryan guy](https://ryanseys.com/blo
 
 ```
 heroku create
-heroku addons:add scheduler
-heroku addons:add sendgrid
+heroku addons:create scheduler
+heroku addons:create sendgrid
 heroku config:set TO=you@youremail.com
 heroku config:set GITHUB_USERNAME=your_github_username
 git push heroku master


### PR DESCRIPTION
resolve this warning by using the new syntax

WARNING: `heroku addons:add` has been deprecated. Please use `heroku addons:create` instead.
